### PR TITLE
Fix commitlint changesets compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Thank you for helping maintain commit quality and consistency!
 - Mt runs: pnpm changeset add
 - Mt commits results when happy with the change set
 - Mt run changeset version 
+
 [WIP]
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Thank you for helping maintain commit quality and consistency!
 - Mt commits results when happy with the change set
 - Mt run changeset version 
 
-[WIP]
+[WIP test]
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Thank you for helping maintain commit quality and consistency!
 - Mt commits results when happy with the change set
 - Mt run changeset version 
 
-[WIP test]
+[WIP]
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Thank you for helping maintain commit quality and consistency!
 - Mt commits results when happy with the change set
 - Mt run changeset version 
 
-[WIP]
+[WIP ]
 
 ## Roadmap
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,25 @@
 export default {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat', // new feature
+        'fix', // bug fix
+        'docs', // documentation
+        'style', // formatting, missing semi colons, etc
+        'refactor', // refactoring code
+        'perf', // performance improvements
+        'test', // adding tests
+        'build', // changes that affect the build system or external dependencies
+        'ci', // changes to CI configuration files and scripts
+        'chore', // other changes that don't modify src or test files
+        'RELEASING' // add your custom type here
+      ],
+    ],
+    // allow changesets "RELEASING: Startcase..." style commits by changeset version to pass
+    'type-case': [2, 'always', ['lower-case', 'upper-case']],
+    'subject-case': [2, 'always', ['lower-case', 'start-case']]
+  },
 };


### PR DESCRIPTION
Loosen commitlint rules to allow changesets "RELEASING: Startcase..."  style commits created by "changeset version" to pass checks,