### PR TITLE
fix(commitlint): to allow changesets version commits to pass checks

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -21,6 +21,6 @@ export default {
     // loosen checking rules to allow changesets "RELEASING: Startcase..." 
     // style commits created by "changeset version" to pass checks
     'type-case': [2, 'always', ['lower-case', 'upper-case']],
-    'subject-case': [2, 'always', ['lower-case', 'start-case']]
+    'subject-case': [2, 'always', ['lower-case', 'sentence-case']]
   },
 };


### PR DESCRIPTION
Loosen commitlint commit checking rules to allow changesets "RELEASING: Sentence case..." style commits created by "changeset version" to pass checks.