### PR TITLE
chore(release): automate changesets release flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,10 @@
-name: Publish release to NPM on release branch merge to main
+name: Release (Changesets)
 
 on:
   push:
-    tags:
-      - v*.*.*
+    branches:
+      - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,13 +13,16 @@ concurrency:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
   
 jobs:
-  build-and-publish:
+  release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -38,26 +42,51 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run Node.js tests
-        run: pnpm test:node
-
-      - name: Build project
-        run: pnpm build
-
-      - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: Run browser tests
-        run: pnpm test:browser
-
-      - name: Publish to npm
-        run: npm publish
-
-      - name: Create GitHub Release
-        uses: actions/create-release@v1
+      - name: Create release PR if needed
+        uses: changesets/action@v1
         with:
-          tag_name: ${{ github.ref_name }}
-          release_name: Release ${{ github.ref_name }}
-          body: "See the latest release notes for details."
+          version: pnpm changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Detect version bump
+        id: version
+        run: |
+          set -euo pipefail
+          current=$(node -p "require('./package.json').version")
+          if git show HEAD^:package.json >/dev/null 2>&1; then
+            previous=$(git show HEAD^:package.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
+          else
+            previous=""
+          fi
+          echo "current=$current" >> $GITHUB_OUTPUT
+          if [ -n "$previous" ] && [ "$current" != "$previous" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run release publish
+        if: steps.version.outputs.changed == 'true'
+        run: pnpm run release:publish
+
+      - name: Tag release
+        if: steps.version.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          version="v${{ steps.version.outputs.current }}"
+          if git rev-parse "$version" >/dev/null 2>&1; then
+            echo "Tag $version already exists"
+          else
+            git tag -a "$version" -m "release $version"
+            git push origin "$version"
+          fi
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.changed == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.current }}
+          name: Release v${{ steps.version.outputs.current }}
+          body: "See the latest release notes for details."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: write
+  id-token: write
   
 jobs:
   build-and-publish:
@@ -26,6 +30,10 @@ jobs:
         with:
           node-version: 20.x
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Ensure npm CLI >= 11.5.1 (trusted publishing)
+        run: npm install -g npm@11.5.1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -42,14 +50,8 @@ jobs:
       - name: Run browser tests
         run: pnpm test:browser
 
-      - name: Configure npm authentication
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-
       - name: Publish to npm
-        run: pnpm changeset publish --no-tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish
 
       - name: Create GitHub Release
         uses: actions/create-release@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,15 @@ To get setup and running, just follow these steps:
    - Tests: Ensure all tests pass.
    - Build: Verify that the project builds successfully.
 
+## Maintainers: Publishing
+
+Publishing to npm is handled by the GitHub Actions workflow on version tags (`v*.*.*`) in `.github/workflows/publish.yml`.
+
+- This repo uses npm **trusted publishing (OIDC)**, so no `NPM_TOKEN` secret is required.
+- Ensure the workflow has `permissions: { id-token: write, contents: write }` and uses npm CLI `>= 11.5.1`.
+- Provenance is generated automatically for public packages from public repos; no `--provenance` flag is required.
+- If you ever switch back to token-based publishing, use a **granular** token with **bypass 2FA** and rotate before expiry.
+
 ### 9. Address CI Results
    - Success: Your PR is ready for review.
    - Failure: Review and resolve issues, then push changes to trigger the CI pipeline again.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,18 +76,65 @@ To get setup and running, just follow these steps:
    - Tests: Ensure all tests pass.
    - Build: Verify that the project builds successfully.
 
-## Maintainers: Publishing
+### 9. Address CI Results
+   - Success: Your PR is ready for review.
+   - Failure: Review and resolve issues, then push changes to trigger the CI pipeline again.
+
+## Maintainers: Publishing (distinct release flow)
+
+This flow is separate from the contributor workflow above. Contributor PRs must not include version bumps; the release PR is the only place `pnpm changeset version` runs.
+
+### Maintainer release process
+1. If you have new changes to land, start from `main`, commit, push, and merge a PR after checks pass.
+
+   ```bash
+   $ git checkout main
+   $ git pull
+   $ git checkout -b some-new-branch
+   $ git commit -m "feat(context): my latest work on feature x"
+   $ git push -u origin some-new-branch
+   ```
+
+   Open the PR on GitHub (copy the URL if you need it later).
+2. Create a clean release branch from updated `main` (delete any local `release` branch first if it exists):
+   
+   ```bash
+   $ git checkout main
+   $ git pull
+   $ git branch -d release
+   $ git checkout -b release
+   ```
+
+3. Prepare the release with Changesets (the `pnpm changeset` step only creates the changeset file; the commit happens in the next step):
+
+   ```bash
+   $ pnpm changeset
+   $ pnpm changeset version
+   ```
+
+   The `version` command bumps versions, updates `CHANGELOG.md`, and creates the commit.
+4. Push the release branch and open a release PR; merge after checks pass. If no CI runs, verify required checks/workflow triggers.
+
+   ```bash
+   $ git push -u origin release
+   ```
+
+5. Tag the release on `main` and push the tag to trigger publishing:
+
+   ```bash
+   $ git checkout main
+   $ git pull
+   $ git tag -a vX.Y.Z -m "release vX.Y.Z"
+   $ git push origin vX.Y.Z
+   ```
 
 Publishing to npm is handled by the GitHub Actions workflow on version tags (`v*.*.*`) in `.github/workflows/publish.yml`.
 
+- Ensure `.github/workflows/publish.yml` is on `main` before tagging so the tag uses the OIDC publish workflow.
 - This repo uses npm **trusted publishing (OIDC)**, so no `NPM_TOKEN` secret is required.
 - Ensure the workflow has `permissions: { id-token: write, contents: write }` and uses npm CLI `>= 11.5.1`.
 - Provenance is generated automatically for public packages from public repos; no `--provenance` flag is required.
 - If you ever switch back to token-based publishing, use a **granular** token with **bypass 2FA** and rotate before expiry.
-
-### 9. Address CI Results
-   - Success: Your PR is ready for review.
-   - Failure: Review and resolve issues, then push changes to trigger the CI pipeline again.
 
 Thank you again for considering making a contribution!
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:browser": "playwright test",
     "test:node": "vitest run",
     "test": "pnpm test:node && pnpm build && start-server-and-test serve:test:browser http://localhost:3000 test:browser",
+    "release:publish": "pnpm test:node && pnpm build && pnpm exec playwright install --with-deps chromium && pnpm test:browser && npm publish",
     "test:node:coverage": "vitest run --coverage",
     "type-check": "tsc --noEmit",
     "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm",

--- a/skills/bookwhen-maintainer-publish/SKILL.md
+++ b/skills/bookwhen-maintainer-publish/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: bookwhen-maintainer-publish
+description: Maintainer release and publishing workflow for the @jphil/bookwhen-client repo, including trusted publishing (OIDC), release tagging, and CI verification. Use when asked to cut a release, publish to npm, update release notes, or troubleshoot publish/auth failures in this repo.
+---
+
+# Maintainer Publishing Workflow (Bookwhen Client)
+
+## Quick path (maintainer flow, distinct from contributor PRs)
+1. Ensure `main` is up to date and CI is green.
+2. If new work is needed, land it via a normal PR and merge to `main`.
+   - `git checkout -b some-new-branch`
+   - `git commit -m "feat(context): my latest work on feature x"`
+   - `git push -u origin some-new-branch`
+3. Create a clean release branch from `main`:
+   - `git checkout main`
+   - `git pull`
+   - `git branch -d release` (if it exists locally)
+   - `git checkout -b release`
+4. Prepare the release with Changesets:
+   - `pnpm changeset` (creates a changeset file; commit happens in the next step)
+   - `pnpm changeset version` (bumps versions, updates `CHANGELOG.md`, commits)
+5. Push the release branch and open a release PR; merge after checks pass.
+   - `git push -u origin release`
+6. Tag and push the release from `main`:
+   - `git checkout main`
+   - `git pull`
+   - `git tag -a vX.Y.Z -m "release vX.Y.Z"`
+   - `git push origin vX.Y.Z`
+7. Monitor the publish workflow and confirm:
+   - npm package version is live
+   - GitHub release is created
+
+## Notes
+- The release PR is the only place version bumps should appear; contributor PRs must not include `pnpm changeset version`.
+
+## Trusted publishing requirements
+- Ensure `.github/workflows/publish.yml` is on `main` before tagging so the tag uses the OIDC publish workflow.
+- Ensure the npm trusted publisher is configured for this repo and `publish.yml`.
+- Ensure workflow permissions include `id-token: write` and `contents: write`.
+- Ensure the workflow runs on GitHub-hosted runners (OIDC requires this).
+- Ensure npm CLI version is >= 11.5.1 in the workflow.
+- Ensure the tag version matches `package.json`.
+
+## Troubleshooting
+- Re-check trusted publisher fields (org/user, repo, workflow filename) and `id-token: write` if npm publish fails to authenticate.
+- If the publish workflow does not run, confirm the tag matches `v*.*.*` and that `publish.yml` exists in the tagged commit.
+- Use a read-only npm token for install only if private dependency installs fail.
+- Expect provenance only for public packages from public repos; it is automatic with trusted publishing.
+
+## Files to consult
+- `.github/workflows/publish.yml`
+- `CONTRIBUTING.md` (maintainer publishing notes)


### PR DESCRIPTION
## Summary\n- switch publish workflow to changesets-driven release PRs on main\n- publish only when package.json version changes; tag + GitHub release after publish\n- document the automated maintainer flow and add release:publish script\n\n## Testing\n- pnpm lint\n- pnpm build\n- pnpm test\n- pnpm check-exports\n